### PR TITLE
Update solidus_drip.js.erb

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_drip.js.erb
+++ b/app/assets/javascripts/spree/frontend/solidus_drip.js.erb
@@ -1,11 +1,11 @@
 var _dcq = _dcq || [];
 var _dcs = _dcs || {};
-_dcs.account = '<%= ENV['DRIP_API_KEY'] %>';
+_dcs.account = '<%= ENV['DRIP_ACCOUNT_ID'] %>';
 
 (function() {
   var dc = document.createElement('script');
   dc.type = 'text/javascript'; dc.async = true;
-  dc.src = '<%= "//tag.getdrip.com/#{ENV['DRIP_API_KEY']}.js" %>';
+  dc.src = '<%= "//tag.getdrip.com/#{ENV['DRIP_ACCOUNT_ID']}.js" %>';
   var s = document.getElementsByTagName('script')[0];
   s.parentNode.insertBefore(dc, s);
 })();


### PR DESCRIPTION
Drip JS requires account id and not the API key

```
<!-- Drip -->
<script type="text/javascript">
  var _dcq = _dcq || [];
  var _dcs = _dcs || {};
  _dcs.account = `your account id`;

  (function() {
    var dc = document.createElement('script');
    dc.type = 'text/javascript'; dc.async = true;
    dc.src = '//tag.getdrip.com/`your account id`.js';
    var s = document.getElementsByTagName('script')[0];
    s.parentNode.insertBefore(dc, s);
  })();
</script>
<!-- end Drip -->
```