### PR TITLE
Add guest_token to Drip cart data

### DIFF
--- a/lib/solidus_drip/shopper_activity/order.rb
+++ b/lib/solidus_drip/shopper_activity/order.rb
@@ -53,6 +53,7 @@ module SolidusDrip
         {
           provider: 'solidus',
           email: order.email,
+          person_id: order.email.nil? ? order.guest_token : nil,
           action: action,
           occurred_at: order.updated_at.iso8601,
           cart_id: order.id.to_s,


### PR DESCRIPTION
Out of the box, this gem throws an error if a guest user adds a product to their cart. You can test this by running the sandbox store and adding an item to your cart without logging in.

The error is related to [this line](https://github.com/DripEmail/drip-ruby/blob/4ed3049b901cd66ce8ce7cc307f03f66fe6fd690/lib/drip/client/shopper_activity.rb#L14) in the `drip-ruby` gem. Basically, Drip wants either an `email`, `person_id`, or `visitor_uuid` at the time the cart is created. `solidus_drip` doesn't doesn't provide any of these keys until after the user logs in.

This PR fixes the problem by using `Spree::Order`'s `guest_token` attribute in the `cart_data` hash until an email address is associated with the order.